### PR TITLE
URL Flock function

### DIFF
--- a/chsql/CMakeLists.txt
+++ b/chsql/CMakeLists.txt
@@ -21,7 +21,7 @@ include_directories(
         ../duckdb/third_party/mbedtls
         ../duckdb/third_party/mbedtls/include
         ../duckdb/third_party/brotli/include)
-set(EXTENSION_SOURCES src/chsql_extension.cpp)
+set(EXTENSION_SOURCES src/chsql_extension.cpp src/duck_flock.cpp)
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})
 # Link OpenSSL in both the static library as the loadable extension

--- a/chsql/src/chsql_extension.cpp
+++ b/chsql/src/chsql_extension.cpp
@@ -179,7 +179,7 @@ static void LoadInternal(DatabaseInstance &instance) {
     ExtensionUtil::RegisterFunction(instance, chsql_openssl_version_scalar_function);
 
     // Macros
-	for (idx_t index = 0; chsql_macros[index].name != nullptr; index++) {
+    for (idx_t index = 0; chsql_macros[index].name != nullptr; index++) {
 		auto info = DefaultFunctionGenerator::CreateInternalMacroInfo(chsql_macros[index]);
 		ExtensionUtil::RegisterFunction(instance, *info);
 	}
@@ -189,6 +189,8 @@ static void LoadInternal(DatabaseInstance &instance) {
         ExtensionUtil::RegisterFunction(instance, *table_info);
 	}
 	ExtensionUtil::RegisterFunction(instance, ReadParquetOrderedFunction());
+    // Flock
+    ExtensionUtil::RegisterFunction(instance, DuckFlockTableFunction());
 }
 
 void ChsqlExtension::Load(DuckDB &db) {

--- a/chsql/src/duck_flock.cpp
+++ b/chsql/src/duck_flock.cpp
@@ -59,7 +59,7 @@ namespace duckdb {
 
     TableFunction DuckFlockTableFunction() {
       TableFunction f(
-          "duck_flock",
+          "url_flock",
           {LogicalType::VARCHAR, LogicalType::LIST(LogicalType::VARCHAR)},
           DuckFlockImplementation,
           DuckFlockBind,

--- a/chsql/src/duck_flock.cpp
+++ b/chsql/src/duck_flock.cpp
@@ -1,8 +1,9 @@
 #ifndef DUCK_FLOCK_H
 #define DUCK_FLOCK_H
 #include "chsql_extension.hpp"
+
 namespace duckdb {
-    struct DuckFlockData : FunctionData{
+    struct DuckFlockData : FunctionData {
         vector<unique_ptr<Connection>> conn;
         vector<unique_ptr<QueryResult>> results;
         unique_ptr<FunctionData> Copy() const override {
@@ -13,66 +14,123 @@ namespace duckdb {
         };
     };
 
-
-
     unique_ptr<FunctionData> DuckFlockBind(ClientContext &context, TableFunctionBindInput &input,
-                                                        vector<LogicalType> &return_types, vector<string> &names) {
+                                         vector<LogicalType> &return_types, vector<string> &names) {
         auto data = make_uniq<DuckFlockData>();
+
+        // Check for NULL input parameters
+        if (input.inputs.empty() || input.inputs.size() < 2) {
+            throw std::runtime_error("url_flock: missing required parameters");
+        }
+        if (input.inputs[0].IsNull() || input.inputs[1].IsNull()) {
+            throw std::runtime_error("url_flock: NULL parameters are not allowed");
+        }
+
         auto strQuery = input.inputs[0].GetValue<string>();
-        vector<string> flock;
+        if (strQuery.empty()) {
+            throw std::runtime_error("url_flock: empty query string");
+        }
+
         auto &raw_flock = ListValue::GetChildren(input.inputs[1]);
+        if (raw_flock.empty()) {
+            throw std::runtime_error("url_flock: empty flock list");
+        }
+
+        bool has_valid_result = false;
+        // Process each connection
         for (auto &duck : raw_flock) {
-            flock.push_back(duck.ToString());
-            auto conn = make_uniq<Connection>(*context.db);
-            conn->Query("SET autoload_known_extensions=1;SET autoinstall_known_extensions=1;");
-            auto req = conn->Prepare("SELECT * FROM read_json($2 || '/?default_format=JSONEachRow&query=' || url_encode($1::VARCHAR))");
-            if (req->HasError()) {
-                throw std::runtime_error("duck_flock: error: " + req->GetError());
+            if (duck.IsNull() || duck.ToString().empty()) {
+                continue;
             }
-            data->conn.push_back(std::move(conn));
-            data->results.push_back(std::move(req->Execute(strQuery.c_str(), duck.ToString())));
+
+            try {
+                auto conn = make_uniq<Connection>(*context.db);
+                if (!conn) {
+                    continue;
+                }
+
+                auto settingResult = conn->Query("SET autoload_known_extensions=1;SET autoinstall_known_extensions=1;");
+                if (settingResult->HasError()) {
+                    continue;
+                }
+
+                auto req = conn->Prepare("SELECT * FROM read_json($2 || '/?default_format=JSONEachRow&query=' || url_encode($1::VARCHAR))");
+                if (req->HasError()) {
+                    continue;
+                }
+
+                auto queryResult = req->Execute(strQuery.c_str(), duck.ToString());
+                if (!queryResult || queryResult->HasError()) {
+                    continue;
+                }
+
+                // Store the first valid result's types and names
+                if (!has_valid_result) {
+                    return_types.clear();
+                    copy(queryResult->types.begin(), queryResult->types.end(), back_inserter(return_types));
+                    names.clear();
+                    copy(queryResult->names.begin(), queryResult->names.end(), back_inserter(names));
+
+                    if (return_types.empty()) {
+                        throw std::runtime_error("url_flock: query must return at least one column");
+                    }
+                    has_valid_result = true;
+                }
+
+                data->conn.push_back(std::move(conn));
+                data->results.push_back(std::move(queryResult));
+            } catch (const std::exception &e) {
+                continue;
+            }
         }
-        if (data->results[0]->HasError()) {
-            throw std::runtime_error("duck_flock: error: " + data->results[0]->GetError());
+
+        // Verify we have at least one valid result
+        if (!has_valid_result || data->results.empty()) {
+            throw std::runtime_error("url_flock: invalid or no results");
         }
-        return_types.clear();
-        copy(data->results[0]->types.begin(), data->results[0]->types.end(), back_inserter(return_types));
-        names.clear();
-        copy(data->results[0]->names.begin(), data->results[0]->names.end(), back_inserter(names));
+
         return std::move(data);
     }
 
-    void DuckFlockImplementation(ClientContext &context, duckdb::TableFunctionInput &data_p,
-                                      DataChunk &output) {
+    void DuckFlockImplementation(ClientContext &context, TableFunctionInput &data_p,
+                               DataChunk &output) {
         auto &data = data_p.bind_data->Cast<DuckFlockData>();
+        
+        if (data.results.empty()) {
+            return;
+        }
+
         for (const auto &res : data.results) {
+            if (!res) {
+                continue;
+            }
+
             ErrorData error_data;
             unique_ptr<DataChunk> data_chunk = make_uniq<DataChunk>();
-            if (res->TryFetch(data_chunk, error_data)) {
-                if (data_chunk != nullptr) {
-                    output.Append(*data_chunk);
-                    return;
+            
+            try {
+                if (res->TryFetch(data_chunk, error_data)) {
+                    if (data_chunk && !data_chunk->size() == 0) {
+                        output.Append(*data_chunk);
+                        return;
+                    }
                 }
+            } catch (...) {
+                continue;
             }
         }
     }
 
     TableFunction DuckFlockTableFunction() {
-      TableFunction f(
-          "url_flock",
-          {LogicalType::VARCHAR, LogicalType::LIST(LogicalType::VARCHAR)},
-          DuckFlockImplementation,
-          DuckFlockBind,
-          nullptr,
-          nullptr
-      );
-      return f;
+        TableFunction f(
+            "url_flock",
+            {LogicalType::VARCHAR, LogicalType::LIST(LogicalType::VARCHAR)},
+            DuckFlockImplementation,
+            DuckFlockBind,
+            nullptr,
+            nullptr
+        );
+        return f;
     }
-
-
 }
-
-
-
-
 #endif

--- a/chsql/src/duck_flock.cpp
+++ b/chsql/src/duck_flock.cpp
@@ -1,0 +1,78 @@
+#ifndef DUCK_FLOCK_H
+#define DUCK_FLOCK_H
+#include "chsql_extension.hpp"
+namespace duckdb {
+    struct DuckFlockData : FunctionData{
+        vector<unique_ptr<Connection>> conn;
+        vector<unique_ptr<QueryResult>> results;
+        unique_ptr<FunctionData> Copy() const override {
+            throw std::runtime_error("not implemented");
+        }
+        bool Equals(const FunctionData &other) const override {
+            throw std::runtime_error("not implemented");
+        };
+    };
+
+
+
+    unique_ptr<FunctionData> DuckFlockBind(ClientContext &context, TableFunctionBindInput &input,
+                                                        vector<LogicalType> &return_types, vector<string> &names) {
+        auto data = make_uniq<DuckFlockData>();
+        auto strQuery = input.inputs[0].GetValue<string>();
+        vector<string> flock;
+        auto &raw_flock = ListValue::GetChildren(input.inputs[1]);
+        for (auto &duck : raw_flock) {
+            flock.push_back(duck.ToString());
+            auto conn = make_uniq<Connection>(*context.db);
+            conn->Query("SET autoload_known_extensions=1;SET autoinstall_known_extensions=1;");
+            auto req = conn->Prepare("SELECT * FROM read_json($2 || '/?q=' || url_encode($1::VARCHAR))");
+            if (req->HasError()) {
+                throw std::runtime_error("duck_flock: error: " + req->GetError());
+            }
+            data->conn.push_back(std::move(conn));
+            data->results.push_back(std::move(req->Execute(strQuery.c_str(), duck.ToString())));
+        }
+        if (data->results[0]->HasError()) {
+            throw std::runtime_error("duck_flock: error: " + data->results[0]->GetError());
+        }
+        return_types.clear();
+        copy(data->results[0]->types.begin(), data->results[0]->types.end(), back_inserter(return_types));
+        names.clear();
+        copy(data->results[0]->names.begin(), data->results[0]->names.end(), back_inserter(names));
+        return std::move(data);
+    }
+
+    void DuckFlockImplementation(ClientContext &context, duckdb::TableFunctionInput &data_p,
+                                      DataChunk &output) {
+        auto &data = data_p.bind_data->Cast<DuckFlockData>();
+        for (const auto &res : data.results) {
+            ErrorData error_data;
+            unique_ptr<DataChunk> data_chunk = make_uniq<DataChunk>();
+            if (res->TryFetch(data_chunk, error_data)) {
+                if (data_chunk != nullptr) {
+                    output.Append(*data_chunk);
+                    return;
+                }
+            }
+        }
+    }
+
+    TableFunction DuckFlockTableFunction() {
+      TableFunction f(
+          "duck_flock",
+          {LogicalType::VARCHAR, LogicalType::LIST(LogicalType::VARCHAR)},
+          DuckFlockImplementation,
+          DuckFlockBind,
+          nullptr,
+          nullptr
+      );
+      return f;
+    }
+
+
+}
+
+
+
+
+#endif

--- a/chsql/src/duck_flock.cpp
+++ b/chsql/src/duck_flock.cpp
@@ -25,7 +25,7 @@ namespace duckdb {
             flock.push_back(duck.ToString());
             auto conn = make_uniq<Connection>(*context.db);
             conn->Query("SET autoload_known_extensions=1;SET autoinstall_known_extensions=1;");
-            auto req = conn->Prepare("SELECT * FROM read_json($2 || '/?q=' || url_encode($1::VARCHAR))");
+            auto req = conn->Prepare("SELECT * FROM read_json($2 || '/?default_format=JSONEachRow&query=' || url_encode($1::VARCHAR))");
             if (req->HasError()) {
                 throw std::runtime_error("duck_flock: error: " + req->GetError());
             }

--- a/chsql/src/include/chsql_extension.hpp
+++ b/chsql/src/include/chsql_extension.hpp
@@ -12,4 +12,7 @@ public:
 };
 duckdb::TableFunction ReadParquetOrderedFunction();
 static void RegisterSillyBTreeStore(DatabaseInstance &instance);
+
+TableFunction DuckFlockTableFunction();
+
 } // namespace duckdb


### PR DESCRIPTION
![duckdb_writer_json-ezgif com-crop](https://github.com/user-attachments/assets/d4aaf390-7693-4713-932c-1ed214c3854b)

## url_flock

The `url_flock` function was inspired by an idea of @carlopi from DuckDB Labs 👋 

When used in combination with the [httpserver extension](https://community-extensions.duckdb.org/extensions/httpserver.html) _(or compatible endpoints such as ClickHouse HTTP using format JSONEachRow)_ the `url_flock` helper builds a multi-backend query with UNON ALL aggregation of results. 

#### Limitations
Currently the  function expects all backends to return the same columns (or no data).


### Examples

```sql
D SELECT * FROM url_flock('SELECT ''hello'', version()', ['http://server1', 'http://server2']);
┌─────────┬─────────────┐
│ 'hello' │ "version"() │
│ varchar │   varchar   │
├─────────┼─────────────┤
│ hello   │ v1.1.1      │
│ hello   │ v1.1.1      │
└─────────┴─────────────┘
```

The construction supports Token based authentication to the [httpserver](https://community-extensions.duckdb.org/extensions/httpserver.html) extension:

```sql
D CREATE SECRET extra_http_headers (
      TYPE HTTP,
      EXTRA_HTTP_HEADERS MAP{
          'X-API-Key': 'secret'
      }
  );
```

### Known Issues
#### HTTP Auth
HEAD requests fail when Basic Auth `user:password@host` is included in the url,. Works with X-Tokens.

- [ ] Debug Basic Authentication handler
